### PR TITLE
Force to use esphome-fork

### DIFF
--- a/esphome-dev/rootfs/etc/cont-init.d/30-esphome-fork.sh
+++ b/esphome-dev/rootfs/etc/cont-init.d/30-esphome-fork.sh
@@ -18,6 +18,7 @@ if bashio::config.has_value 'esphome_fork'; then
       username="esphome"
       ref=$esphome_fork
     fi
+    rm -rf /esphome || bashio::exit.nok "Failed to remove ESPHome."
     full_url="https://github.com/${username}/esphome/archive/${ref}.tar.gz"
     bashio::log.info "Checking forked ESPHome"
     dev_version=$(python3 -c "from esphome.const import __version__; print(__version__)")
@@ -25,10 +26,10 @@ if bashio::config.has_value 'esphome_fork'; then
     curl -L -o /tmp/esphome.tar.gz "${full_url}" -qq \
       || bashio::exit.nok "Failed downloading ESPHome fork."
     bashio::log.info "Installing ESPHome from fork '${esphome_fork}' (${full_url})..."
-    mkdir /esphome-fork
-    tar -zxf /tmp/esphome.tar.gz -C /esphome-fork --strip-components=1 \
+    mkdir /esphome
+    tar -zxf /tmp/esphome.tar.gz -C /esphome --strip-components=1 \
       || bashio::exit.nok "Failed installing ESPHome from fork."
-    pip install -U -e /esphome-fork || bashio::exit.nok "Failed installing ESPHome from fork."
+    pip install -U -e /esphome || bashio::exit.nok "Failed installing ESPHome from fork."
     rm -f /tmp/esphome.tar.gz
     fork_version=$(python3 -c "from esphome.const import __version__; print(__version__)")
 

--- a/esphome-dev/rootfs/etc/cont-init.d/30-esphome-fork.sh
+++ b/esphome-dev/rootfs/etc/cont-init.d/30-esphome-fork.sh
@@ -18,7 +18,6 @@ if bashio::config.has_value 'esphome_fork'; then
       username="esphome"
       ref=$esphome_fork
     fi
-    rm -rf /esphome || bashio::exit.nok "Failed to remove ESPHome."
     full_url="https://github.com/${username}/esphome/archive/${ref}.tar.gz"
     bashio::log.info "Checking forked ESPHome"
     dev_version=$(python3 -c "from esphome.const import __version__; print(__version__)")
@@ -26,6 +25,7 @@ if bashio::config.has_value 'esphome_fork'; then
     curl -L -o /tmp/esphome.tar.gz "${full_url}" -qq \
       || bashio::exit.nok "Failed downloading ESPHome fork."
     bashio::log.info "Installing ESPHome from fork '${esphome_fork}' (${full_url})..."
+    rm -rf /esphome || bashio::exit.nok "Failed to remove ESPHome."
     mkdir /esphome
     tar -zxf /tmp/esphome.tar.gz -C /esphome --strip-components=1 \
       || bashio::exit.nok "Failed installing ESPHome from fork."


### PR DESCRIPTION
The esphome fork this install into esphome-fork directoty but the docker image run the dashboard form esphome directory. 
That why the fork source must be write to esphome directory.