### PR TITLE
Add Home Assistant integration discovery

### DIFF
--- a/esphome-beta/config.yaml
+++ b/esphome-beta/config.yaml
@@ -16,9 +16,12 @@ ports:
 map:
 - ssl:ro
 - config:rw
+discovery:
+- esphome
 schema:
   status_use_ping: bool?
   streamer_mode: bool?
+  home_assistant_dashboard_integration: bool?
   default_compile_process_limit: int(1,)?
   ssl: bool?
   certfile: str?
@@ -35,3 +38,5 @@ description: Beta version of ESPHome add-on
 image: ghcr.io/esphome/esphome-hassio
 stage: experimental
 advanced: true
+options:
+  home_assistant_dashboard_integration: false

--- a/esphome-beta/translations/en.yaml
+++ b/esphome-beta/translations/en.yaml
@@ -23,6 +23,13 @@ configuration:
 
       Please note that the fork or branch you are using **must** be up to
       date with ESPHome dev or the add-on **will not start**.
+  home_assistant_dashboard_integration:
+    name: Home Assistant Dashboard Integration
+    description: >-
+      Enables/Disables the ESPHome dashboard integrating with Home Assistant
+      for automatic configuration of devices and device updates. If you use
+      multiple version of the ESPHome add-on, make sure it is enabled on a
+      single add-on only.
   keyfile:
     name: Private key file
     description: >-

--- a/esphome-dev/config.yaml
+++ b/esphome-dev/config.yaml
@@ -16,6 +16,8 @@ ports:
 map:
 - ssl:ro
 - config:rw
+discovery:
+- esphome
 schema:
   status_use_ping: bool?
   streamer_mode: bool?
@@ -35,3 +37,5 @@ slug: esphome-dev
 description: Development version of ESPHome add-on
 stage: experimental
 advanced: true
+options:
+  home_assistant_dashboard_integration: false

--- a/esphome-dev/translations/en.yaml
+++ b/esphome-dev/translations/en.yaml
@@ -23,6 +23,13 @@ configuration:
 
       Please note that the fork or branch you are using **must** be up to
       date with ESPHome dev or the add-on **will not start**.
+  home_assistant_dashboard_integration:
+    name: Home Assistant Dashboard Integration
+    description: >-
+      Enables/Disables the ESPHome dashboard integrating with Home Assistant
+      for automatic configuration of devices and device updates. If you use
+      multiple version of the ESPHome add-on, make sure it is enabled on a
+      single add-on only.
   keyfile:
     name: Private key file
     description: >-

--- a/esphome/config.yaml
+++ b/esphome/config.yaml
@@ -16,9 +16,12 @@ ports:
 map:
 - ssl:ro
 - config:rw
+discovery:
+- esphome
 schema:
   status_use_ping: bool?
   streamer_mode: bool?
+  home_assistant_dashboard_integration: bool?
   default_compile_process_limit: int(1,)?
   ssl: bool?
   certfile: str?

--- a/esphome/translations/en.yaml
+++ b/esphome/translations/en.yaml
@@ -23,6 +23,13 @@ configuration:
 
       Please note that the fork or branch you are using **must** be up to
       date with ESPHome dev or the add-on **will not start**.
+  home_assistant_dashboard_integration:
+    name: Home Assistant Dashboard Integration
+    description: >-
+      Enables/Disables the ESPHome dashboard integrating with Home Assistant
+      for automatic configuration of devices and device updates. If you use
+      multiple version of the ESPHome add-on, make sure it is enabled on a
+      single add-on only.
   keyfile:
     name: Private key file
     description: >-

--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -24,9 +24,12 @@ base: &base
   map:
     - ssl:ro
     - config:rw
+  discovery:
+    - esphome
   schema:
     status_use_ping: bool?
     streamer_mode: bool?
+    home_assistant_dashboard_integration: bool?
     default_compile_process_limit: int(1,)?
     ssl: bool?
     certfile: str?
@@ -59,6 +62,8 @@ esphome-dev:
     relative_url: str?
     leave_front_door_open: bool?
   base_image: ghcr.io/esphome/esphome-hassio:dev
+  options:
+      home_assistant_dashboard_integration: false
 
 esphome-beta:
   <<: *base
@@ -71,6 +76,8 @@ esphome-beta:
   image: ghcr.io/esphome/esphome-hassio
   stage: experimental
   advanced: true
+  options:
+      home_assistant_dashboard_integration: false
 
 esphome-stable:
   <<: *base

--- a/template/translations/en.yaml
+++ b/template/translations/en.yaml
@@ -23,6 +23,13 @@ configuration:
 
       Please note that the fork or branch you are using **must** be up to
       date with ESPHome dev or the add-on **will not start**.
+  home_assistant_dashboard_integration:
+    name: Home Assistant Dashboard Integration
+    description: >-
+      Enables/Disables the ESPHome dashboard integrating with Home Assistant
+      for automatic configuration of devices and device updates. If you use
+      multiple version of the ESPHome add-on, make sure it is enabled on a
+      single add-on only.
   keyfile:
     name: Private key file
     description: >-


### PR DESCRIPTION
Add Home Assistant integration discovery for ESPHome. 

By default, it is enabled on the stable version of the add-on (implicit) and disabled on the beta & dev add-ons (explicit).
