### PR TITLE
Remove superfluous period from description in add-on config

### DIFF
--- a/esphome/config.yaml
+++ b/esphome/config.yaml
@@ -35,5 +35,5 @@ panel_title: ESPHome Builder
 version: 2025.3.2
 slug: esphome
 description: Build your own smart home devices using ESPHome, no programming experience
-  required.
+  required
 image: ghcr.io/esphome/esphome-hassio

--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -88,7 +88,7 @@ esphome-stable:
   panel_title: ESPHome Builder
   version: "2025.3.2"  # STABLE
   slug: esphome
-  description: "Build your own smart home devices using ESPHome, no programming experience required."
+  description: "Build your own smart home devices using ESPHome, no programming experience required"
   image: ghcr.io/esphome/esphome-hassio
 
 copy_files:


### PR DESCRIPTION
The description string gets rendered with a period at the end in Home Assistant. Having a period at the end of the description leads to two periods being rendered.

This patch removes the superfluous period from the description in config.yaml and also from the description in template/addon_config.yaml.