### PR TITLE
Update Device Builder toggle name to indicate Preview status

### DIFF
--- a/template/translations/en.yaml
+++ b/template/translations/en.yaml
@@ -64,7 +64,7 @@ configuration:
       potentially private information. So for example WiFi (B)SSIDs (which could
       be used to find your location), usernames, etc.
   use_new_device_builder:
-    name: Use new Device Builder
+    name: Use new Device Builder Preview
     description: >-
       Use the new ESPHome Device Builder instead of the classic ESPHome
       dashboard. When enabled, the latest prerelease of `esphome-device-builder`


### PR DESCRIPTION
Updates the configuration option name for the new Device Builder toggle to make it clearer that this is a preview feature.