### PR TITLE
Deep merge base config keys when generating channel configs

### DIFF
--- a/esphome-beta/config.yaml
+++ b/esphome-beta/config.yaml
@@ -26,10 +26,14 @@ schema:
   certfile: str?
   keyfile: str?
   leave_front_door_open: bool?
+  use_new_device_builder: bool?
 backup_exclude:
 - '*/*/'
 init: false
 startup: services
+options:
+  home_assistant_dashboard_integration: false
+  use_new_device_builder: false
 name: ESPHome Device Builder (beta)
 panel_title: ESPHome Builder (beta)
 version: 2026.4.5
@@ -37,5 +41,3 @@ slug: esphome-beta
 description: Beta version of ESPHome Device Builder
 image: ghcr.io/esphome/esphome-hassio
 stage: experimental
-options:
-  home_assistant_dashboard_integration: false

--- a/esphome-dev/config.yaml
+++ b/esphome-dev/config.yaml
@@ -32,6 +32,9 @@ backup_exclude:
 - '*/*/'
 init: false
 startup: services
+options:
+  home_assistant_dashboard_integration: false
+  use_new_device_builder: false
 name: ESPHome Device Builder (dev)
 panel_title: ESPHome Builder (dev)
 version: 2026.5.0-dev20260506
@@ -39,6 +42,3 @@ slug: esphome-dev
 description: Development version of ESPHome Device Builder
 image: ghcr.io/esphome/esphome-hassio
 stage: experimental
-options:
-  home_assistant_dashboard_integration: false
-  use_new_device_builder: false

--- a/esphome/config.yaml
+++ b/esphome/config.yaml
@@ -26,10 +26,13 @@ schema:
   certfile: str?
   keyfile: str?
   leave_front_door_open: bool?
+  use_new_device_builder: bool?
 backup_exclude:
 - '*/*/'
 init: false
 startup: services
+options:
+  use_new_device_builder: false
 name: ESPHome Device Builder
 panel_title: ESPHome Builder
 version: 2026.4.5

--- a/script/generate.py
+++ b/script/generate.py
@@ -16,6 +16,16 @@ class Channel(Enum):
     dev = "dev"
 
 
+def deep_merge(base, override):
+    result = dict(override)
+    for key, base_value in base.items():
+        if key not in override:
+            result[key] = base_value
+        elif isinstance(base_value, dict) and isinstance(override[key], dict):
+            result[key] = deep_merge(base_value, override[key])
+    return result
+
+
 def main(args):
     parser = argparse.ArgumentParser(
         description="Generate ESPHome Home Assistant config.json"
@@ -30,9 +40,10 @@ def main(args):
         config = yaml.safe_load(f)
 
     copyf = config["copy_files"]
+    base = config.get("base") or {}
 
     for channel in args.channels:
-        conf = config[f"esphome-{channel.value}"]
+        conf = deep_merge(base, config[f"esphome-{channel.value}"])
         dir_ = root / conf.pop("directory")
         path = dir_ / "config.yaml"
         with open(path, "w", encoding="utf-8") as f:

--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -34,12 +34,15 @@ base: &base
     certfile: str?
     keyfile: str?
     leave_front_door_open: bool?
+    use_new_device_builder: bool?
   backup_exclude:
     - "*/*/"
   # Disable docker init for s6
   init: false
   # Make sure dashboard is available for core
   startup: services
+  options:
+    use_new_device_builder: false
 
 esphome-dev:
   <<: *base
@@ -62,10 +65,8 @@ esphome-dev:
     certfile: str?
     keyfile: str?
     leave_front_door_open: bool?
-    use_new_device_builder: bool?
   options:
     home_assistant_dashboard_integration: false
-    use_new_device_builder: false
 
 esphome-beta:
   <<: *base


### PR DESCRIPTION
## Summary

YAML's `<<: *base` only does a shallow merge, so a channel defining its own `options:` or `schema:` would replace the base block entirely instead of inheriting unspecified entries. For example, `esphome-dev` and `esphome-beta` were dropping `use_new_device_builder: false` from `options` because they each declare their own `options:` block.

`script/generate.py` now does a recursive merge: base values fill in missing keys at any depth, while channel values still win on conflicts. `use_new_device_builder` has been moved into the shared `base` schema/options so all three channels inherit it consistently, and the regenerated `config.yaml` files reflect the merged result.