### PR TITLE
Enable new Device Builder by default on dev and beta apps

### DIFF
--- a/esphome-beta/config.yaml
+++ b/esphome-beta/config.yaml
@@ -33,7 +33,7 @@ init: false
 startup: services
 options:
   home_assistant_dashboard_integration: false
-  use_new_device_builder: false
+  use_new_device_builder: true
 name: ESPHome Device Builder (beta)
 panel_title: ESPHome Builder (beta)
 version: 2026.4.5

--- a/esphome-dev/config.yaml
+++ b/esphome-dev/config.yaml
@@ -34,7 +34,7 @@ init: false
 startup: services
 options:
   home_assistant_dashboard_integration: false
-  use_new_device_builder: false
+  use_new_device_builder: true
 name: ESPHome Device Builder (dev)
 panel_title: ESPHome Builder (dev)
 version: 2026.5.0-dev20260512

--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -67,6 +67,7 @@ esphome-dev:
     leave_front_door_open: bool?
   options:
     home_assistant_dashboard_integration: false
+    use_new_device_builder: true
 
 esphome-beta:
   <<: *base
@@ -81,6 +82,7 @@ esphome-beta:
   stage: experimental
   options:
     home_assistant_dashboard_integration: false
+    use_new_device_builder: true
 
 esphome-stable:
   <<: *base


### PR DESCRIPTION
## Summary
- Default `use_new_device_builder` to `true` for the **dev** and **beta** apps so prerelease users get the new Device Builder Preview out of the box.
- Stable app keeps the classic dashboard as default.
- Users can still opt back to the classic dashboard via the addon configuration toggle in either app.

## Test plan
- [ ] Install the dev app fresh — confirm the new Device Builder is the default experience.
- [ ] Install the beta app fresh — same check.
- [ ] Confirm the stable app remains unchanged (classic dashboard by default).
- [ ] Verify existing installs that already have an explicit `use_new_device_builder: false` keep their preference on update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)