### PR TITLE
fix: use mdi:chip for sidebar icon (mdi:esphome doesn't exist)

### DIFF
--- a/esphome-beta/config.yaml
+++ b/esphome-beta/config.yaml
@@ -8,7 +8,7 @@ auth_api: true
 host_network: true
 ingress: true
 ingress_port: 0
-panel_icon: mdi:esphome
+panel_icon: mdi:chip
 uart: true
 ports:
   6052/tcp: null

--- a/esphome-dev/config.yaml
+++ b/esphome-dev/config.yaml
@@ -8,7 +8,7 @@ auth_api: true
 host_network: true
 ingress: true
 ingress_port: 0
-panel_icon: mdi:esphome
+panel_icon: mdi:chip
 uart: true
 ports:
   6052/tcp: null

--- a/esphome/config.yaml
+++ b/esphome/config.yaml
@@ -8,7 +8,7 @@ auth_api: true
 host_network: true
 ingress: true
 ingress_port: 0
-panel_icon: mdi:esphome
+panel_icon: mdi:chip
 uart: true
 ports:
   6052/tcp: null

--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -15,7 +15,7 @@ base: &base
   # Ingress settings
   ingress: true
   ingress_port: 0
-  panel_icon: "mdi:esphome"
+  panel_icon: "mdi:chip"
   # Automatically add UART devices to App
   uart: true
   ports:


### PR DESCRIPTION
## Problem

The `panel_icon` is currently `mdi:esphome`, but **no icon by that name exists** in the Material Design Icons set bundled with Home Assistant. You can verify by searching the upstream [Templarian/MaterialDesign-SVG](https://github.com/Templarian/MaterialDesign-SVG/tree/master/svg) — there's no `esphome.svg`.

As a result, the ESPHome Builder sidebar entry renders without an icon on both the web frontend and the HA mobile companion app, leaving an empty space where the icon should be. HACS sits right next to it and renders fine because HACS ships its own iconset (`hacs:hacs`).

Note: PR #231 moved `panel_icon` into the shared template base but kept the value as `mdi:esphome`, so the rendering issue persists.

## Fix

Switch to `mdi:chip`, which is a real MDI icon that visually reads as a microcontroller — a natural fit for ESPHome.

## Alternatives considered

- **`mdi:memory`** — fine but slightly more generic.
- **`mdi:circuit-board`** — reads as a PCB rather than a chip.
- **Custom iconset** (like HACS does with `hacs:hacs`) — bigger change. If that's the eventual goal, this change is trivially revertible once a custom iconset lands.

## Verification

Tested locally against HA 2026.4.4: icon renders correctly in the sidebar (web) and the iOS companion app after this change.

## Files changed

- `template/addon_config.yaml` (base template)
- `esphome/config.yaml`
- `esphome-beta/config.yaml`
- `esphome-dev/config.yaml`

Happy to switch to a different MDI icon if maintainers prefer something else. The important thing is moving off the nonexistent name.