### PR TITLE
Remove use_new_device_builder option from templates

### DIFF
--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -34,15 +34,12 @@ base: &base
     certfile: str?
     keyfile: str?
     leave_front_door_open: bool?
-    use_new_device_builder: bool?
   backup_exclude:
     - "*/*/"
   # Disable docker init for s6
   init: false
   # Make sure dashboard is available for core
   startup: services
-  options:
-    use_new_device_builder: false
 
 esphome-dev:
   <<: *base
@@ -67,7 +64,6 @@ esphome-dev:
     leave_front_door_open: bool?
   options:
     home_assistant_dashboard_integration: false
-    use_new_device_builder: true
 
 esphome-beta:
   <<: *base
@@ -82,7 +78,6 @@ esphome-beta:
   stage: experimental
   options:
     home_assistant_dashboard_integration: false
-    use_new_device_builder: true
 
 esphome-stable:
   <<: *base

--- a/template/translations/en.yaml
+++ b/template/translations/en.yaml
@@ -63,12 +63,5 @@ configuration:
       Enables/Disables streamer mode, which makes ESPHome hide all
       potentially private information. So for example WiFi (B)SSIDs (which could
       be used to find your location), usernames, etc.
-  use_new_device_builder:
-    name: Use new Device Builder Preview
-    description: >-
-      Use the new ESPHome Device Builder instead of the classic ESPHome
-      dashboard. When enabled, the latest prerelease of `esphome-device-builder`
-      is installed on container start. **This is experimental and may not yet
-      have all the features of the classic dashboard.**
 network:
   6052/tcp: Web interface (to use without Home Assistant)


### PR DESCRIPTION
The `use_new_device_builder` option is no longer needed as an opt-in flag. This removes it from the template files so the next releases regenerate the per-addon configs without it.

Removed from `template/addon_config.yaml`: the `use_new_device_builder: bool?` schema entry, the now-empty base `options` block, and the `use_new_device_builder: true` option from the `esphome-dev` and `esphome-beta` channels. Also removed the corresponding configuration entry from `template/translations/en.yaml`.

The generated per-addon `config.yaml`/`translations` files are intentionally left untouched — they drop the option when regenerated on the next releases.

Dont merge until https://github.com/esphome/esphome/pull/16994 is merged otherwise the dev app will break