### PR TITLE
Remove unused SSL, status_use_ping, streamer_mode and relative_url options

### DIFF
--- a/esphome-beta/DOCS.md
+++ b/esphome-beta/DOCS.md
@@ -5,9 +5,8 @@ The installation of this App is pretty straightforward and not different in comp
 
 1. Search for the "ESPHome" App in the Supervisor App store.
 2. Press install to download the App and unpack it on your machine. This can take some time.
-3. Optional: If you're using SSL/TLS certificates and want to encrypt your communication to this App, please enter `true` into the `ssl` field and set the `fullchain` and `certfile` options accordingly.
-4. Start the App, check the logs of the App to see if everything went well.
-5. Click "OPEN WEB UI" to open the ESPHome dashboard. You will be asked for your Home Assistant credentials - ESPHome uses Home Assistant's authentication system to log you in.
+3. Start the App, check the logs of the App to see if everything went well.
+4. Click "OPEN WEB UI" to open the ESPHome dashboard. You will be asked for your Home Assistant credentials - ESPHome uses Home Assistant's authentication system to log you in.
 
 You can view the ESPHome documentation at https://esphome.io/
 
@@ -15,57 +14,7 @@ You can view the ESPHome documentation at https://esphome.io/
 
 **Note**: _Remember to restart the App when the configuration is changed._
 
-Example App configuration:
-
-```json
-{
-  "ssl": false,
-  "certfile": "fullchain.pem",
-  "keyfile": "privkey.pem"
-}
-```
-
-### Option: `ssl`
-
-Enables or disables encrypted SSL/TLS (HTTPS) connections to the web server of this App.
-Set it to `true` to encrypt communications, `false` otherwise.
-Please note that if you set this to `true` you must also generate the key and certificate
-files for encryption. For example using [Let's Encrypt](https://www.home-assistant.io/addons/lets_encrypt/)
-or [Self-signed certificates](https://www.home-assistant.io/docs/ecosystem/certificates/tls_self_signed_certificate/).
-
-### Option: `certfile`
-
-The certificate file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
-### Option: `keyfile`
-
-The private key file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
 ### Option: `leave_front_door_open`
 
 Adding this option to the App configuration allows you to disable
 authentication by setting it to `true`.
-
-### Option: `relative_url`
-
-Host the ESPHome dashboard under a relative URL, so that it can be integrated
-into existing web proxies like NGINX under a relative URL. Defaults to `/`.
-
-### Option: `status_use_ping`
-
-By default the dashboard uses mDNS to check if nodes are online. This does
-not work across subnets unless your router supports mDNS forwarding or avahi.
-
-Setting this to `true` will make ESPHome use ICMP ping requests to get the node status. Use this if all nodes always have offline status even when they're connected.
-
-### Option: `streamer_mode`
-
-If set to `true`, this will enable streamer mode, which makes ESPHome hide all
-potentially private information. So for example WiFi (B)SSIDs (which could be
-used to find your location), usernames, etc. Please note that you need to use
-the `!secret` tag in your YAML file to also prevent these from showing up
-while editing and validating.

--- a/esphome-beta/config.yaml
+++ b/esphome-beta/config.yaml
@@ -13,18 +13,12 @@ uart: true
 ports:
   6052/tcp: null
 map:
-- ssl:ro
 - config:rw
 discovery:
 - esphome
 schema:
-  status_use_ping: bool?
-  streamer_mode: bool?
   home_assistant_dashboard_integration: bool?
   default_compile_process_limit: int(1,)?
-  ssl: bool?
-  certfile: str?
-  keyfile: str?
   leave_front_door_open: bool?
 backup_exclude:
 - '*/*/'

--- a/esphome-beta/translations/en.yaml
+++ b/esphome-beta/translations/en.yaml
@@ -1,10 +1,5 @@
 ---
 configuration:
-  certfile:
-    name: Certificate file
-    description: >-
-      The certificate file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
   default_compile_process_limit:
     name: Default compile process limit
     description: >-
@@ -30,38 +25,10 @@ configuration:
       for automatic configuration of devices and device updates. If you use
       multiple version of the ESPHome App, make sure it is enabled on a
       single App only.
-  keyfile:
-    name: Private key file
-    description: >-
-      The private key file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
   leave_front_door_open:
     name: Disable external authentication
     description: >-
       Disables external authentication when having opened the App
       on an external port. **WARNING**: This is a security risk!
-  relative_url:
-    name: Relative URL
-    description: >-
-      Host the ESPHome dashboard under a relative URL, so that it can be
-      integrated into existing web proxies like NGINX under a relative URL.
-      Defaults to `/`.
-  ssl:
-    name: SSL
-    description: >-
-      Enables/Disables SSL (HTTPS) on the web interface.
-  status_use_ping:
-    name: Use ping for status
-    description: >-
-      By default the dashboard uses mDNS to check if nodes are online. This does
-      not work across subnets unless your router supports mDNS forwarding
-      or avahi. Enabling this option will use ICMP ping to check if nodes are
-      online.
-  streamer_mode:
-    name: Streamer mode
-    description: >-
-      Enables/Disables streamer mode, which makes ESPHome hide all
-      potentially private information. So for example WiFi (B)SSIDs (which could
-      be used to find your location), usernames, etc.
 network:
   6052/tcp: Web interface (to use without Home Assistant)

--- a/esphome-dev/DOCS.md
+++ b/esphome-dev/DOCS.md
@@ -27,47 +27,7 @@ or the App **will not start**.
 
 General options also available in other versions.
 
-### Option: `ssl`
-
-Enables or disables encrypted SSL/TLS (HTTPS) connections to the web server of this App.
-Set it to `true` to encrypt communications, `false` otherwise.
-Please note that if you set this to `true` you must also generate the key and certificate
-files for encryption. For example using [Let's Encrypt](https://www.home-assistant.io/addons/lets_encrypt/)
-or [Self-signed certificates](https://www.home-assistant.io/docs/ecosystem/certificates/tls_self_signed_certificate/).
-
-### Option: `certfile`
-
-The certificate file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
-### Option: `keyfile`
-
-The private key file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
 ### Option: `leave_front_door_open`
 
 Adding this option to the App configuration allows you to disable
 authentication by setting it to `true`.
-
-### Option: `relative_url`
-
-Host the ESPHome dashboard under a relative URL, so that it can be integrated
-into existing web proxies like NGINX under a relative URL. Defaults to `/`.
-
-### Option: `status_use_ping`
-
-By default the dashboard uses mDNS to check if nodes are online. This does
-not work across subnets unless your router supports mDNS forwarding or avahi.
-
-Setting this to `true` will make ESPHome use ICMP ping requests to get the node status. Use this if all nodes always have offline status even when they're connected.
-
-### Option: `streamer_mode`
-
-If set to `true`, this will enable streamer mode, which makes ESPHome hide all
-potentially private information. So for example WiFi (B)SSIDs (which could be
-used to find your location), usernames, etc. Please note that you need to use
-the `!secret` tag in your YAML file to also prevent these from showing up
-while editing and validating.

--- a/esphome-dev/config.yaml
+++ b/esphome-dev/config.yaml
@@ -13,19 +13,13 @@ uart: true
 ports:
   6052/tcp: null
 map:
-- ssl:ro
 - config:rw
 discovery:
 - esphome
 schema:
-  status_use_ping: bool?
-  streamer_mode: bool?
   home_assistant_dashboard_integration: bool?
   default_compile_process_limit: int(1,)?
   esphome_fork: str?
-  ssl: bool?
-  certfile: str?
-  keyfile: str?
   leave_front_door_open: bool?
 backup_exclude:
 - '*/*/'

--- a/esphome-dev/translations/en.yaml
+++ b/esphome-dev/translations/en.yaml
@@ -1,10 +1,5 @@
 ---
 configuration:
-  certfile:
-    name: Certificate file
-    description: >-
-      The certificate file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
   default_compile_process_limit:
     name: Default compile process limit
     description: >-
@@ -30,38 +25,10 @@ configuration:
       for automatic configuration of devices and device updates. If you use
       multiple version of the ESPHome App, make sure it is enabled on a
       single App only.
-  keyfile:
-    name: Private key file
-    description: >-
-      The private key file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
   leave_front_door_open:
     name: Disable external authentication
     description: >-
       Disables external authentication when having opened the App
       on an external port. **WARNING**: This is a security risk!
-  relative_url:
-    name: Relative URL
-    description: >-
-      Host the ESPHome dashboard under a relative URL, so that it can be
-      integrated into existing web proxies like NGINX under a relative URL.
-      Defaults to `/`.
-  ssl:
-    name: SSL
-    description: >-
-      Enables/Disables SSL (HTTPS) on the web interface.
-  status_use_ping:
-    name: Use ping for status
-    description: >-
-      By default the dashboard uses mDNS to check if nodes are online. This does
-      not work across subnets unless your router supports mDNS forwarding
-      or avahi. Enabling this option will use ICMP ping to check if nodes are
-      online.
-  streamer_mode:
-    name: Streamer mode
-    description: >-
-      Enables/Disables streamer mode, which makes ESPHome hide all
-      potentially private information. So for example WiFi (B)SSIDs (which could
-      be used to find your location), usernames, etc.
 network:
   6052/tcp: Web interface (to use without Home Assistant)

--- a/esphome/DOCS.md
+++ b/esphome/DOCS.md
@@ -5,9 +5,8 @@ The installation of this App is pretty straightforward and not different in comp
 
 1. Search for the "ESPHome" App in the Supervisor App store.
 2. Press install to download the App and unpack it on your machine. This can take some time.
-3. Optional: If you're using SSL/TLS certificates and want to encrypt your communication to this App, please enter `true` into the `ssl` field and set the `fullchain` and `certfile` options accordingly.
-4. Start the App, check the logs of the App to see if everything went well.
-5. Click "OPEN WEB UI" to open the ESPHome dashboard. You will be asked for your Home Assistant credentials - ESPHome uses Home Assistant's authentication system to log you in.
+3. Start the App, check the logs of the App to see if everything went well.
+4. Click "OPEN WEB UI" to open the ESPHome dashboard. You will be asked for your Home Assistant credentials - ESPHome uses Home Assistant's authentication system to log you in.
 
 You can view the ESPHome documentation at https://esphome.io/
 
@@ -15,57 +14,7 @@ You can view the ESPHome documentation at https://esphome.io/
 
 **Note**: _Remember to restart the App when the configuration is changed._
 
-Example App configuration:
-
-```json
-{
-  "ssl": false,
-  "certfile": "fullchain.pem",
-  "keyfile": "privkey.pem"
-}
-```
-
-### Option: `ssl`
-
-Enables or disables encrypted SSL/TLS (HTTPS) connections to the web server of this App.
-Set it to `true` to encrypt communications, `false` otherwise.
-Please note that if you set this to `true` you must also generate the key and certificate
-files for encryption. For example using [Let's Encrypt](https://www.home-assistant.io/addons/lets_encrypt/)
-or [Self-signed certificates](https://www.home-assistant.io/docs/ecosystem/certificates/tls_self_signed_certificate/).
-
-### Option: `certfile`
-
-The certificate file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
-### Option: `keyfile`
-
-The private key file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
 ### Option: `leave_front_door_open`
 
 Adding this option to the App configuration allows you to disable
 authentication by setting it to `true`.
-
-### Option: `relative_url`
-
-Host the ESPHome dashboard under a relative URL, so that it can be integrated
-into existing web proxies like NGINX under a relative URL. Defaults to `/`.
-
-### Option: `status_use_ping`
-
-By default the dashboard uses mDNS to check if nodes are online. This does
-not work across subnets unless your router supports mDNS forwarding or avahi.
-
-Setting this to `true` will make ESPHome use ICMP ping requests to get the node status. Use this if all nodes always have offline status even when they're connected.
-
-### Option: `streamer_mode`
-
-If set to `true`, this will enable streamer mode, which makes ESPHome hide all
-potentially private information. So for example WiFi (B)SSIDs (which could be
-used to find your location), usernames, etc. Please note that you need to use
-the `!secret` tag in your YAML file to also prevent these from showing up
-while editing and validating.

--- a/esphome/config.yaml
+++ b/esphome/config.yaml
@@ -13,18 +13,12 @@ uart: true
 ports:
   6052/tcp: null
 map:
-- ssl:ro
 - config:rw
 discovery:
 - esphome
 schema:
-  status_use_ping: bool?
-  streamer_mode: bool?
   home_assistant_dashboard_integration: bool?
   default_compile_process_limit: int(1,)?
-  ssl: bool?
-  certfile: str?
-  keyfile: str?
   leave_front_door_open: bool?
 backup_exclude:
 - '*/*/'

--- a/esphome/translations/en.yaml
+++ b/esphome/translations/en.yaml
@@ -1,10 +1,5 @@
 ---
 configuration:
-  certfile:
-    name: Certificate file
-    description: >-
-      The certificate file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
   default_compile_process_limit:
     name: Default compile process limit
     description: >-
@@ -30,38 +25,10 @@ configuration:
       for automatic configuration of devices and device updates. If you use
       multiple version of the ESPHome App, make sure it is enabled on a
       single App only.
-  keyfile:
-    name: Private key file
-    description: >-
-      The private key file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
   leave_front_door_open:
     name: Disable external authentication
     description: >-
       Disables external authentication when having opened the App
       on an external port. **WARNING**: This is a security risk!
-  relative_url:
-    name: Relative URL
-    description: >-
-      Host the ESPHome dashboard under a relative URL, so that it can be
-      integrated into existing web proxies like NGINX under a relative URL.
-      Defaults to `/`.
-  ssl:
-    name: SSL
-    description: >-
-      Enables/Disables SSL (HTTPS) on the web interface.
-  status_use_ping:
-    name: Use ping for status
-    description: >-
-      By default the dashboard uses mDNS to check if nodes are online. This does
-      not work across subnets unless your router supports mDNS forwarding
-      or avahi. Enabling this option will use ICMP ping to check if nodes are
-      online.
-  streamer_mode:
-    name: Streamer mode
-    description: >-
-      Enables/Disables streamer mode, which makes ESPHome hide all
-      potentially private information. So for example WiFi (B)SSIDs (which could
-      be used to find your location), usernames, etc.
 network:
   6052/tcp: Web interface (to use without Home Assistant)

--- a/template/DOCS.md
+++ b/template/DOCS.md
@@ -5,9 +5,8 @@ The installation of this App is pretty straightforward and not different in comp
 
 1. Search for the "ESPHome" App in the Supervisor App store.
 2. Press install to download the App and unpack it on your machine. This can take some time.
-3. Optional: If you're using SSL/TLS certificates and want to encrypt your communication to this App, please enter `true` into the `ssl` field and set the `fullchain` and `certfile` options accordingly.
-4. Start the App, check the logs of the App to see if everything went well.
-5. Click "OPEN WEB UI" to open the ESPHome dashboard. You will be asked for your Home Assistant credentials - ESPHome uses Home Assistant's authentication system to log you in.
+3. Start the App, check the logs of the App to see if everything went well.
+4. Click "OPEN WEB UI" to open the ESPHome dashboard. You will be asked for your Home Assistant credentials - ESPHome uses Home Assistant's authentication system to log you in.
 
 You can view the ESPHome documentation at https://esphome.io/
 
@@ -15,57 +14,7 @@ You can view the ESPHome documentation at https://esphome.io/
 
 **Note**: _Remember to restart the App when the configuration is changed._
 
-Example App configuration:
-
-```json
-{
-  "ssl": false,
-  "certfile": "fullchain.pem",
-  "keyfile": "privkey.pem"
-}
-```
-
-### Option: `ssl`
-
-Enables or disables encrypted SSL/TLS (HTTPS) connections to the web server of this App.
-Set it to `true` to encrypt communications, `false` otherwise.
-Please note that if you set this to `true` you must also generate the key and certificate
-files for encryption. For example using [Let's Encrypt](https://www.home-assistant.io/addons/lets_encrypt/)
-or [Self-signed certificates](https://www.home-assistant.io/docs/ecosystem/certificates/tls_self_signed_certificate/).
-
-### Option: `certfile`
-
-The certificate file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
-### Option: `keyfile`
-
-The private key file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
 ### Option: `leave_front_door_open`
 
 Adding this option to the App configuration allows you to disable
 authentication by setting it to `true`.
-
-### Option: `relative_url`
-
-Host the ESPHome dashboard under a relative URL, so that it can be integrated
-into existing web proxies like NGINX under a relative URL. Defaults to `/`.
-
-### Option: `status_use_ping`
-
-By default the dashboard uses mDNS to check if nodes are online. This does
-not work across subnets unless your router supports mDNS forwarding or avahi.
-
-Setting this to `true` will make ESPHome use ICMP ping requests to get the node status. Use this if all nodes always have offline status even when they're connected.
-
-### Option: `streamer_mode`
-
-If set to `true`, this will enable streamer mode, which makes ESPHome hide all
-potentially private information. So for example WiFi (B)SSIDs (which could be
-used to find your location), usernames, etc. Please note that you need to use
-the `!secret` tag in your YAML file to also prevent these from showing up
-while editing and validating.

--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -21,18 +21,12 @@ base: &base
   ports:
     "6052/tcp": null
   map:
-    - ssl:ro
     - config:rw
   discovery:
     - esphome
   schema:
-    status_use_ping: bool?
-    streamer_mode: bool?
     home_assistant_dashboard_integration: bool?
     default_compile_process_limit: int(1,)?
-    ssl: bool?
-    certfile: str?
-    keyfile: str?
     leave_front_door_open: bool?
   backup_exclude:
     - "*/*/"
@@ -53,14 +47,9 @@ esphome-dev:
   image: ghcr.io/esphome/esphome-hassio
   stage: experimental
   schema:
-    status_use_ping: bool?
-    streamer_mode: bool?
     home_assistant_dashboard_integration: bool?
     default_compile_process_limit: int(1,)?
     esphome_fork: str?
-    ssl: bool?
-    certfile: str?
-    keyfile: str?
     leave_front_door_open: bool?
   options:
     home_assistant_dashboard_integration: false

--- a/template/dev/DOCS.md
+++ b/template/dev/DOCS.md
@@ -27,47 +27,7 @@ or the App **will not start**.
 
 General options also available in other versions.
 
-### Option: `ssl`
-
-Enables or disables encrypted SSL/TLS (HTTPS) connections to the web server of this App.
-Set it to `true` to encrypt communications, `false` otherwise.
-Please note that if you set this to `true` you must also generate the key and certificate
-files for encryption. For example using [Let's Encrypt](https://www.home-assistant.io/addons/lets_encrypt/)
-or [Self-signed certificates](https://www.home-assistant.io/docs/ecosystem/certificates/tls_self_signed_certificate/).
-
-### Option: `certfile`
-
-The certificate file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
-### Option: `keyfile`
-
-The private key file to use for SSL. If this file doesn't exist, the App start will fail.
-
-**Note**: The file MUST be stored in `/ssl/`, which is the default for Home Assistant
-
 ### Option: `leave_front_door_open`
 
 Adding this option to the App configuration allows you to disable
 authentication by setting it to `true`.
-
-### Option: `relative_url`
-
-Host the ESPHome dashboard under a relative URL, so that it can be integrated
-into existing web proxies like NGINX under a relative URL. Defaults to `/`.
-
-### Option: `status_use_ping`
-
-By default the dashboard uses mDNS to check if nodes are online. This does
-not work across subnets unless your router supports mDNS forwarding or avahi.
-
-Setting this to `true` will make ESPHome use ICMP ping requests to get the node status. Use this if all nodes always have offline status even when they're connected.
-
-### Option: `streamer_mode`
-
-If set to `true`, this will enable streamer mode, which makes ESPHome hide all
-potentially private information. So for example WiFi (B)SSIDs (which could be
-used to find your location), usernames, etc. Please note that you need to use
-the `!secret` tag in your YAML file to also prevent these from showing up
-while editing and validating.

--- a/template/translations/en.yaml
+++ b/template/translations/en.yaml
@@ -1,10 +1,5 @@
 ---
 configuration:
-  certfile:
-    name: Certificate file
-    description: >-
-      The certificate file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
   default_compile_process_limit:
     name: Default compile process limit
     description: >-
@@ -30,38 +25,10 @@ configuration:
       for automatic configuration of devices and device updates. If you use
       multiple version of the ESPHome App, make sure it is enabled on a
       single App only.
-  keyfile:
-    name: Private key file
-    description: >-
-      The private key file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
   leave_front_door_open:
     name: Disable external authentication
     description: >-
       Disables external authentication when having opened the App
       on an external port. **WARNING**: This is a security risk!
-  relative_url:
-    name: Relative URL
-    description: >-
-      Host the ESPHome dashboard under a relative URL, so that it can be
-      integrated into existing web proxies like NGINX under a relative URL.
-      Defaults to `/`.
-  ssl:
-    name: SSL
-    description: >-
-      Enables/Disables SSL (HTTPS) on the web interface.
-  status_use_ping:
-    name: Use ping for status
-    description: >-
-      By default the dashboard uses mDNS to check if nodes are online. This does
-      not work across subnets unless your router supports mDNS forwarding
-      or avahi. Enabling this option will use ICMP ping to check if nodes are
-      online.
-  streamer_mode:
-    name: Streamer mode
-    description: >-
-      Enables/Disables streamer mode, which makes ESPHome hide all
-      potentially private information. So for example WiFi (B)SSIDs (which could
-      be used to find your location), usernames, etc.
 network:
   6052/tcp: Web interface (to use without Home Assistant)


### PR DESCRIPTION
## Summary

General cleanup of addon config options that are no longer consumed.

SSL termination was removed from the app along with nginx, so the `ssl`, `certfile` and `keyfile` options — plus the `/ssl` (`ssl:ro`) mount that existed only to read those cert files — no longer do anything and are removed.

`status_use_ping`, `streamer_mode` and `relative_url` have no remaining consumers in the new `esphome-device-builder`:

- `status_use_ping` is read by no live run script or backend code.
- `streamer_mode` (`ESPHOME_STREAMER_MODE`) is unused — the legacy dashboard hid resolved secrets unless streamer mode was off; the new builder inverts the default so secrets are hidden unless the user passes `show_secrets` per request.
- `relative_url` (`ESPHOME_DASHBOARD_RELATIVE_URL`) is unused — the builder now derives the ingress base path per-request from Supervisor's `X-Ingress-Path` header.

Every remaining schema option (`home_assistant_dashboard_integration`, `default_compile_process_limit`, `esphome_fork`, `leave_front_door_open`) is confirmed to still be consumed.

Changes were made to the `template/` sources; the `esphome`, `esphome-beta` and `esphome-dev` directories were regenerated.

> [!NOTE]
> The matching dead env-var exports (`ESPHOME_STREAMER_MODE`, `ESPHOME_DASHBOARD_RELATIVE_URL`) in the `esphome` repo's addon run script are removed in the companion PR esphome/esphome#17140.