### PR TITLE
remove additional logo

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -1,7 +1,4 @@
 # ESPHome Device Builder
-
-[![ESPHome logo][logo]][website]
-
 [![GitHub stars][github-stars-shield]][repository]
 [![Discord][discord-shield]][discord]
 


### PR DESCRIPTION
I've removed the logomark, because it is already displayed above in the HA apps detail screen.
<img width="746" height="792" alt="image" src="https://github.com/user-attachments/assets/6d3b04e9-19bf-4ae1-9dda-a7a54d440f45" />
