### PR TITLE
Expose per-link port into config

### DIFF
--- a/template/addon_config.yaml
+++ b/template/addon_config.yaml
@@ -20,6 +20,7 @@ base: &base
   uart: true
   ports:
     "6052/tcp": null
+    "6055/tcp": null
   map:
     - config:rw
   discovery:

--- a/template/translations/en.yaml
+++ b/template/translations/en.yaml
@@ -32,3 +32,4 @@ configuration:
       on an external port. **WARNING**: This is a security risk!
 network:
   6052/tcp: Web interface (to use without Home Assistant)
+  6055/tcp: Peer link (for remote build server pairing)


### PR DESCRIPTION
Expose per-link port into config to use addon instance as remote build server